### PR TITLE
feature: add support for enable/disable http or https

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,56 @@ ingress:
       secretName: ingress-tls
 ```
 
+### Only enable TLS access to EJBCA
+If you would like to only allow inbound TLS connections to EJBCA do not assert a value for the port number. The service and pod will only listen on TLS. This does not work for AJP `services.proxyAJP`.
+
+#### Direct HTTP option
+
+```yaml
+services:
+  # not recommended, should only be used for debugging purpose
+  directHttp:
+    enabled: true
+    type: NodePort
+    httpPort: 
+    httpsPort: 30443
+
+```
+
+#### Load Balancer with nginx deployed in EJBCA pod
+
+```yaml
+services:
+  proxyHttp:
+    enabled: false
+    type: LoadBalancer
+    bindIP: 0.0.0.0
+    httpPort:
+    httpsPort: 443
+
+nginx:
+  enabled: true
+  host: "enroll.ejbca.test"
+  proxy_url_host: localhost
+  service:
+    enabled: false
+    type: NodePort
+    httpPort: 
+    httpsPort: 443
+```
+
+#### Proxy HTTP
+
+```yaml
+services:
+  proxyHttp:
+    enabled: false
+    type: ClusterIP
+    bindIP: 0.0.0.0
+    httpPort:
+    httpsPort: 8082
+```
+
 ### Using init containers and sidecar containers
 
 The init containers and sidecar containers can be used to customize the deployment (for example, if you need to run security module service as additional container, or do some extra validation before EJBCA startup). The following example shows how to use sidecar containers (init containers are configured the same way):

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -84,10 +84,14 @@ spec:
         - name: {{ template "ejbca.fullname" . }}-nginx
           image: nginx:alpine
           ports:
+          {{- if .Values.nginx.service.httpPort }}
           - name: nginx-http
             containerPort: 80
+          {{- end }}
+          {{- if .Values.nginx.service.httpsPort }}
           - name: nginx-https
             containerPort: 443
+          {{- end }}
           startupProbe:
             tcpSocket:
               port: 443
@@ -138,9 +142,12 @@ spec:
                     {{- end }}
           ports:
             {{- if .Values.services.directHttp.enabled }}
+            {{- if .Values.services.directHttp.httpPort }}
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- end }}
+            {{- if .Values.services.directHttp.httpsPort }}  
             - name: https
               containerPort: 8443
               protocol: TCP
@@ -151,12 +158,16 @@ spec:
               protocol: TCP
             {{- end }}
             {{- if .Values.services.proxyHttp.enabled }}
+            {{- if .Values.services.proxyHttp.httpPort }}
             - name: proxy-http
               containerPort: 8081
               protocol: TCP
+            {{- end }}
+            {{- if .Values.services.proxyHttp.httpsPort }}  
             - name: proxy-https
               containerPort: 8082
               protocol: TCP
+            {{- end }}
             {{- end }}
           startupProbe:
             tcpSocket:

--- a/templates/nginx-service.yaml
+++ b/templates/nginx-service.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   type: {{ .Values.nginx.service.type }}
   ports:
+    {{- if .Values.nginx.service.httpPort }}
     - name: nginx-http
       port: {{ .Values.nginx.service.httpPort }}
       {{- if eq .Values.nginx.service.type "NodePort" }}
@@ -13,6 +14,8 @@ spec:
       {{- end }}
       targetPort: nginx-http
       protocol: TCP
+    {{- end }}
+    {{- if .Values.nginx.service.httpsPort }}
     - name: nginx-https
       port: {{ .Values.nginx.service.httpsPort }}
       {{- if eq .Values.nginx.service.type "NodePort" }}
@@ -20,6 +23,7 @@ spec:
       {{- end }}
       targetPort: nginx-https
       protocol: TCP
+    {{- end }}
   selector:
     {{- include "ejbca.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   type: {{ .Values.services.directHttp.type }}
   ports:
+    {{- if .Values.services.directHttp.httpPort }}
     - port: {{ .Values.services.directHttp.httpPort }}
       {{- if eq .Values.services.directHttp.type "NodePort" }}
       nodePort: {{ .Values.services.directHttp.httpPort }}
@@ -15,6 +16,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- end }}
+    {{- if .Values.services.directHttp.httpsPort }}
     - port: {{ .Values.services.directHttp.httpsPort }}
       {{- if eq .Values.services.directHttp.type "NodePort" }}
       nodePort: {{ .Values.services.directHttp.httpsPort }}
@@ -22,6 +25,7 @@ spec:
       targetPort: https
       protocol: TCP
       name: https
+    {{- end }}
     {{- if and .Values.ejbca.sidecarContainers .Values.services.sidecarPorts }}
       {{- toYaml .Values.services.sidecarPorts | nindent 4 }}
     {{- end }}
@@ -47,8 +51,9 @@ spec:
   type: {{ .Values.services.proxyHttp.type }}
   {{- if eq .Values.services.proxyHttp.type "LoadBalancer" }}
   sessionAffinity: ClientIP
-  {{- end }}      
+  {{- end }}
   ports:
+    {{- if .Values.services.proxyHttp.httpPort }}
     - port: {{ .Values.services.proxyHttp.httpPort }}
       {{- if eq .Values.services.proxyHttp.type "NodePort" }}
       nodePort: {{ .Values.services.proxyHttp.httpPort }}
@@ -60,6 +65,8 @@ spec:
       {{- end }}
       protocol: TCP
       name: proxy-http
+    {{- end }}
+    {{- if .Values.services.proxyHttp.httpsPort }}
     - port: {{ .Values.services.proxyHttp.httpsPort }}
       {{- if eq .Values.services.proxyHttp.type "NodePort" }}
       nodePort: {{ .Values.services.proxyHttp.httpsPort }}
@@ -71,6 +78,7 @@ spec:
       {{- end }}
       protocol: TCP
       name: proxy-https
+    {{- end }}
   selector:
     {{- include "ejbca.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -127,7 +127,7 @@ services:
   # are defined and need to expose ports
   sidecarPorts: []
 
-# Requires proxyHttp service to be enabled
+# Requires services.proxyHttp to be enabled
 nginx:
   enabled: false
   # hostname used in the commonName of the TLS certificate issued for nginx


### PR DESCRIPTION
Add option to enable/disable HTTP or HTTPS port for accessing the container. For instance an RA or CA may only want TLS enabled inbound and not HTTP, while a VA may only want HTTP and no TLS access.