### PR TITLE
fix targetPort for ProxyHTTPS

### DIFF
--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -74,7 +74,7 @@ spec:
       {{- if eq .Values.services.proxyHttp.type "LoadBalancer" }}
       targetPort: nginx-https
       {{- else }}
-      targetPort: proxy-http
+      targetPort: proxy-https
       {{- end }}
       protocol: TCP
       name: proxy-https


### PR DESCRIPTION
Patch https://github.com/Keyfactor/ejbca-community-helm/commit/747162a23567cc13c7fe0c94e259067c80706ef4 introduced bug. `targetPort` is always `proxy-http` when `LoadBalancer` is not used.

Part of `values.yaml` I'm using:
```yaml
services:
  directHttp:
    enabled: false
  proxyAJP:
    enabled: false
  proxyHttp:
    enabled: true
    type: ClusterIP
    bindIP: 0.0.0.0
    httpPort: 8081
    httpsPort: 8082
```

Service helm is creating:
```yaml
$ helm --namespace test upgrade -i --values=values.yaml ejbca https://keyfactor.github.io/ejbca-community-helm/ejbca-community-helm-1.0.7.tgz --dry-run | grep -A 24 ejbca-community-helm/templates/services.yaml
# Source: ejbca-community-helm/templates/services.yaml
apiVersion: v1
kind: Service
metadata:
  name: ejbca-ejbca-community-helm
  labels:
    helm.sh/chart: ejbca-community-helm-1.0.7
    app.kubernetes.io/name: ejbca-community-helm
    app.kubernetes.io/instance: ejbca
    app.kubernetes.io/version: "8.2.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 8081
      targetPort: proxy-http
      protocol: TCP
      name: proxy-http
    - port: 8082
      targetPort: proxy-http
      protocol: TCP
      name: proxy-https
  selector:
    app.kubernetes.io/name: ejbca-community-helm
    app.kubernetes.io/instance: ejbca
```

It should be:
```yaml
...
  ports:
    - port: 8081
      targetPort: proxy-http
      protocol: TCP
      name: proxy-http
    - port: 8082
      targetPort: proxy-https
      protocol: TCP
      name: proxy-https
```
