### PR TITLE
Add LoadBalancer IP and Ablity to change Issueing CA for nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,10 +588,13 @@ The following lists other variables that provide additional miscellaneous capabi
 | nginx.proxy_url_host       | The hostname used to proxy from NGINX to EJBCA. When NGINX is in the same pod as EJBCA use localhost |          |
 | nginx.mountInternalNginxCert | Use a Secret mounted TLS certificate, private key, and CA cert for NGINX. Use when there is no active CA or use a TLS cert not issued by the ManagementCA |          |
 | nginx.secretInternalNginxCert | Name of the secret that contains the certificate, key, and CA certificate |          |
+| nginx.issuingCA            | Changes the CA to issue the cert out of                                | ManagementCA |
+| nginx.certificateProfile   | Changes the profile to issue the certificate out of                    | SERVER |
 | nginx.service.enabled      | Creates a service for accessing EJBCA. This should be used when using `services.proxyHttp.type=LoadBalancer` | false    |
 | nginx.service.type         | Type of service to create for NGINX reverse proxy                      | NodePort |
 | nginx.service.httpPort     | HTTP port to use for NGINX reverse proxy. Do not assert a value to disable HTTP at the service | 30080    |
 | nginx.service.httpsPort    | HTTPS port to use for NGINX reverse proxy                              | 30443    |
+| nginx.service.loadBalancerIP | When using NGINX as a load balancer service type, Optionaly specify the load balancer IP address for network controllers to use (Type must be load balancer) | UNSET |
 | nginx.conf                 | NGINX server configuration parameters                                  |          |
 
 ### Ingress Parameters

--- a/README.md
+++ b/README.md
@@ -589,7 +589,8 @@ The following lists other variables that provide additional miscellaneous capabi
 | nginx.mountInternalNginxCert | Use a Secret mounted TLS certificate, private key, and CA cert for NGINX. Use when there is no active CA or use a TLS cert not issued by the ManagementCA |          |
 | nginx.secretInternalNginxCert | Name of the secret that contains the certificate, key, and CA certificate |          |
 | nginx.issuingCA            | Changes the CA to issue the cert out of                                | ManagementCA |
-| nginx.certificateProfile   | Changes the profile to issue the certificate out of                    | SERVER |
+| nginx.certificateProfile   | Changes the profile to issue the certificate out of                    | SERVER   |
+| nginx.resetEndEntity       | Removes the previous end entity Used when rotating the CA out.         | false    |
 | nginx.service.enabled      | Creates a service for accessing EJBCA. This should be used when using `services.proxyHttp.type=LoadBalancer` | false    |
 | nginx.service.type         | Type of service to create for NGINX reverse proxy                      | NodePort |
 | nginx.service.httpPort     | HTTP port to use for NGINX reverse proxy. Do not assert a value to disable HTTP at the service | 30080    |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,6 +59,10 @@ spec:
               until [ -f /opt/keyfactor/appserver/standalone/deployments/ejbca.ear.deployed ]; do sleep 5; done
               until [[ $(/opt/keyfactor/bin/ejbca.sh roles listadmins --role "Super Administrator Role" | grep -v 'USERNAME TYPE_EQUALCASE "ejbca"') ]]; do sleep 5; done
               sleep 5
+              {{- if .Values.nginx.resetEndEntity }}
+              /opt/keyfactor/bin/ejbca.sh ra revokeendentity --username '{{ .Values.nginx.host }}' -r 0
+              /opt/keyfactor/bin/ejbca.sh ra delendentity --username '{{ .Values.nginx.host }}' -force
+              {{- end }}
               /opt/keyfactor/bin/ejbca.sh ra addendentity --username '{{ .Values.nginx.host }}' --dn 'CN={{ .Values.nginx.host }}' --caname '{{ .Values.nginx.issuingCA }}' --type 1 --token PEM --altname 'dNSName={{ .Values.nginx.host }}' --certprofile '{{ .Values.nginx.certificateProfile }}' --password NOTUSED
               /opt/keyfactor/bin/ejbca.sh ra setendentitystatus --username '{{ .Values.nginx.host }}' -S 10
               /opt/keyfactor/bin/ejbca.sh ra setclearpwd '{{ .Values.nginx.host }}' NOTUSED

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               until [ -f /opt/keyfactor/appserver/standalone/deployments/ejbca.ear.deployed ]; do sleep 5; done
               until [[ $(/opt/keyfactor/bin/ejbca.sh roles listadmins --role "Super Administrator Role" | grep -v 'USERNAME TYPE_EQUALCASE "ejbca"') ]]; do sleep 5; done
               sleep 5
-              /opt/keyfactor/bin/ejbca.sh ra addendentity --username '{{ .Values.nginx.host }}' --dn 'CN={{ .Values.nginx.host }}' --caname 'ManagementCA' --type 1 --token PEM --altname 'dNSName={{ .Values.nginx.host }}' --certprofile SERVER --password NOTUSED
+              /opt/keyfactor/bin/ejbca.sh ra addendentity --username '{{ .Values.nginx.host }}' --dn 'CN={{ .Values.nginx.host }}' --caname '{{ .Values.nginx.issuingCA }}' --type 1 --token PEM --altname 'dNSName={{ .Values.nginx.host }}' --certprofile {{ .Values.nginx.certificateProfile }} --password NOTUSED
               /opt/keyfactor/bin/ejbca.sh ra setendentitystatus --username '{{ .Values.nginx.host }}' -S 10
               /opt/keyfactor/bin/ejbca.sh ra setclearpwd '{{ .Values.nginx.host }}' NOTUSED
               /opt/keyfactor/bin/ejbca.sh batch '{{ .Values.nginx.host }}' -dir /tmp/nginx/ssl/

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               until [ -f /opt/keyfactor/appserver/standalone/deployments/ejbca.ear.deployed ]; do sleep 5; done
               until [[ $(/opt/keyfactor/bin/ejbca.sh roles listadmins --role "Super Administrator Role" | grep -v 'USERNAME TYPE_EQUALCASE "ejbca"') ]]; do sleep 5; done
               sleep 5
-              /opt/keyfactor/bin/ejbca.sh ra addendentity --username '{{ .Values.nginx.host }}' --dn 'CN={{ .Values.nginx.host }}' --caname '{{ .Values.nginx.issuingCA }}' --type 1 --token PEM --altname 'dNSName={{ .Values.nginx.host }}' --certprofile {{ .Values.nginx.certificateProfile }} --password NOTUSED
+              /opt/keyfactor/bin/ejbca.sh ra addendentity --username '{{ .Values.nginx.host }}' --dn 'CN={{ .Values.nginx.host }}' --caname '{{ .Values.nginx.issuingCA }}' --type 1 --token PEM --altname 'dNSName={{ .Values.nginx.host }}' --certprofile '{{ .Values.nginx.certificateProfile }}' --password NOTUSED
               /opt/keyfactor/bin/ejbca.sh ra setendentitystatus --username '{{ .Values.nginx.host }}' -S 10
               /opt/keyfactor/bin/ejbca.sh ra setclearpwd '{{ .Values.nginx.host }}' NOTUSED
               /opt/keyfactor/bin/ejbca.sh batch '{{ .Values.nginx.host }}' -dir /tmp/nginx/ssl/

--- a/templates/nginx-service.yaml
+++ b/templates/nginx-service.yaml
@@ -26,4 +26,7 @@ spec:
     {{- end }}
   selector:
     {{- include "ejbca.selectorLabels" . | nindent 4 }}
+  {{- if eq .Values.nginx.service.type "LoadBalancer" (.Values.nginx.service.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.nginx.service.loadBalancerIP }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -138,6 +138,10 @@ nginx:
   mountInternalNginxCert: false
   # Name of the secret that contains the certificate, key, and CA certificate
   secretInternalNginxCert: "internal-nginx-credential-secret-ca"
+  # After you have setup your root or subordinate CA, you can use the following to issue a certificate for nginx from that CA Insted
+  issuingCA: ManagementCA
+  # The certificate profile to use when issuing the certificate for nginx
+  certificateProfile: SERVER
   service:
     enabled: false
     type: NodePort

--- a/values.yaml
+++ b/values.yaml
@@ -147,6 +147,8 @@ nginx:
     type: NodePort
     httpPort: 30080
     httpsPort: 30443
+    # When using NGINX as a load balancer service type, you can specify the load balancer IP address for network controllers to use (ig metallb)
+    loadBalancerIP:
  
 # Requires proxyAJP or proxyHttp service to be enabled for adminweb access
 ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -142,6 +142,8 @@ nginx:
   issuingCA: ManagementCA
   # The certificate profile to use when issuing the certificate for nginx
   certificateProfile: SERVER
+  # Removes the end entity and revokes all certificates (used for swapping out the CA) (not recommended to keep on)
+  resetEndEntity: false
   service:
     enabled: false
     type: NodePort


### PR DESCRIPTION
I already have to have a post patch for the load balancer IP so tidying it into the main repo would be great!

Additional, I want to move everything onto my main CA change that would have been pushed out to clients. Others wishing to do the same, make sure that you have a cert chain to login under your custom CA and that you have another issuing CA created in the first place